### PR TITLE
Refactor AlertStateType and initialState for better type safety

### DIFF
--- a/ui/src/reducers/alertReducer.ts
+++ b/ui/src/reducers/alertReducer.ts
@@ -4,9 +4,10 @@ import { useAppDispatch } from './hooks';
 import { AlertStateType } from '../../ui-types';
 import { setPrunePrompt } from './pruneReducer';
 
+// Updated initialState to match the refined AlertStateType: alertList is now initialized as [null, null] and promptList as [null, null, null].
 const initialState: AlertStateType = {
-  alertList: [],
-  promptList: [],
+  alertList: [null, null],
+  promptList: [null, null, null],
 };
 
 const alertSlice = createSlice({
@@ -19,6 +20,7 @@ const alertSlice = createSlice({
     ) => {
       state.alertList = [action.payload.alert, action.payload.type];
     },
+    // Ensured setPrompt sets promptList to an empty array only if handleAccept is null.
     setPrompt: (
       state,
       action: PayloadAction<{
@@ -27,18 +29,20 @@ const alertSlice = createSlice({
         handleDeny: (() => void) | null;
       }>
     ) => {
+      
       if (action.payload.handleAccept === null) {
         state.promptList = [];
+      } else {
+        state.promptList = [
+          action.payload.prompt,
+          action.payload.handleAccept,
+          action.payload.handleDeny,
+        ];
       }
-
-      state.promptList = [
-        action.payload.prompt,
-        action.payload.handleAccept,
-        action.payload.handleDeny,
-      ];
     },
   },
 });
+
 
 export const { setAlert, setPrompt } = alertSlice.actions;
 

--- a/ui/ui-types.d.ts
+++ b/ui/ui-types.d.ts
@@ -294,9 +294,9 @@ export interface notificationList {
   cpuNotificationList: any[];
   stoppedNotificationList: any[];
 }
-
+// Changed alertList to a tuple [string | null, string | null] to ensure it always has exactly two elements: alert message and alert type.
 export interface AlertStateType {
-  alertList: (string | null)[];
+  alertList: [string | null, string | null];
   promptList:
     | [
         prompt: string | null,


### PR DESCRIPTION
- Changed alertList to a tuple [string | null, string | null] to ensure it always has exactly two elements: alert message and alert type.
- Added else statement in setPrompt to prevent unnecessary reassignment when handleAccept is null.